### PR TITLE
Support 4 property errors for Java lambdas

### DIFF
--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -155,7 +155,7 @@ class LambdaOutputParser:
             # the keys 'errorMessage' and 'errorType'.
             if (
                 isinstance(lambda_response_dict, dict)
-                and len(lambda_response_dict) in [2, 3]
+                and len(lambda_response_dict) in [2, 3, 4]
                 and "errorMessage" in lambda_response_dict
                 and "errorType" in lambda_response_dict
             ):


### PR DESCRIPTION
*Issue #1404 *

When a Java thrown exception has a cause, the `start-lambda` runtime does not mark it as a failure. When it does not have a cause, it does.

*How does it address the issue?*
Supports 4 property dicts as sent by Java.

*What side effects does this change have?*
Unknown?

*Checklist:*

- [X] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [X] Write unit tests
- [X] Write/update functional tests
- [X] Write/update integration tests
- [X] `make pr` passes
- [X] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
